### PR TITLE
Preserve context edits when they exceed the size limit

### DIFF
--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -1523,15 +1523,16 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			break
 		}
 
+		if len(context) > pers.ContextMaxBytes {
+			// Don't remove the temporary file so the user's edits aren't
+			// lost; they can shorten the content and re-open it.
+			m.errorMsg = fmt.Sprintf("The content you entered is too large (max %d bytes); your edits were preserved at %s, shorten it and re-open", pers.ContextMaxBytes, msg.fPath)
+			break
+		}
+
 		err = os.Remove(msg.fPath)
 		if err != nil {
 			m.errorMsg = fmt.Sprintf("warning: omm failed to remove temporary file: %s", err)
-		}
-
-		if len(context) > pers.ContextMaxBytes {
-			m.errorMsg = "The content you entered is too large, maybe shorten it"
-			// TODO: allow reopening the text editor with the same content again
-			break
 		}
 
 		if len(context) == 0 && msg.oldContext == nil {


### PR DESCRIPTION
## Summary

When a task's context is edited in an external editor and the saved content
exceeds `pers.ContextMaxBytes` (1 MiB), the `textEditorClosed` handler in
`internal/ui/update.go` removed the temporary file *before* the size check, so
the over-limit branch discarded the user's edits with no way to recover them.

This moves the size check ahead of the file removal. On the over-limit path the
temp file is now kept on disk, and the error message names its location so the
user can recover their text, shorten it, and re-open the editor. The success
path still removes the temp file exactly as before.

## Why this matters

Issue #65 reports that editing a large context silently throws the work away.
As the issue puts it, "the main thing I would like is for work to not be lost."
The existing `// TODO: allow reopening the text editor with the same content
again` at the over-limit branch confirmed this was the intended direction. The
1 MiB cap is unchanged; this is purely about not losing work.

## Testing

- `go build ./...`, `go vet ./...`, `gofmt -l .` / `gofumpt -l .`: clean
- `go test ./...`: all packages pass
- Behavior:
  - Content under 1 MiB: saved normally, temp file removed (unchanged)
  - Content over 1 MiB: error names the preserved temp-file path, file remains on disk
  - Editor error / read error: existing paths preserved (temp file still removed on editor error)
  - Empty content with no prior context: still a no-op

Fixes #65

AI was used for assistance.
